### PR TITLE
Update Dockerfile with opentelemetry-instrument wrapper 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN opentelemetry-bootstrap --action=install
 
 USER 1000
 
-CMD ["python", "app.py"]
+CMD ["opentelemetry-instrument", "python3", "app.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask-cors
 flask_httpauth
 flasgger==0.9.7.1
 # Add the fertiscan-pipeline package from GitHub
-git+https://github.com/ai-cfia/fertiscan-pipeline.git@main
+git+https://github.com/ai-cfia/fertiscan-pipeline.git@v0.0.1
 # Add the datastore to interact with the database
 git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.1-fertiscan-datastore
 psycopg[pool]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask-cors
 flask_httpauth
 flasgger==0.9.7.1
 # Add the fertiscan-pipeline package from GitHub
-git+https://github.com/ai-cfia/fertiscan-pipeline.git@v0.0.1
+git+https://github.com/ai-cfia/fertiscan-pipeline.git@v0.0.2
 # Add the datastore to interact with the database
 git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.1-fertiscan-datastore
 psycopg[pool]


### PR DESCRIPTION
closes #186 
Also fixes requirement of fertiscan-pipeline with package version. 