### PR TITLE
issue #181: get inspections fastapi

### DIFF
--- a/app/controllers/inspections.py
+++ b/app/controllers/inspections.py
@@ -1,0 +1,52 @@
+import asyncio
+
+from fertiscan import get_user_analysis_by_verified
+
+from app.connection_manager import ConnectionManager
+from app.exceptions import MissingUserAttributeError
+from app.models.inspection import InspectionData
+from app.models.users import User
+
+
+async def read_all(cm: ConnectionManager, user: User):
+    """
+    Retrieves all inspections associated with a user, both verified and unverified.
+
+    Args:
+        cm (ConnectionManager): Database connection manager.
+        user (User): User instance containing user details, including the user ID.
+
+    Returns:
+        list[InspectionData]: A list of `InspectionData` objects representing
+        all inspections related to the user, with fields such as `upload_date`,
+        `updated_at`, `product_name`, and more.
+    """
+
+    if not user.id:
+        raise MissingUserAttributeError("User id is required for fetching inspections.")
+
+    with cm, cm.get_cursor() as cursor:
+        inspections = await asyncio.gather(
+            get_user_analysis_by_verified(cursor, user.id, True),
+            get_user_analysis_by_verified(cursor, user.id, False),
+        )
+
+        # Flatten and transform results into InspectionData objects
+        inspections = [
+            InspectionData(
+                id=entry[0],
+                upload_date=entry[1],
+                updated_at=entry[2],
+                sample_id=entry[3],
+                picture_set_id=entry[4],
+                label_info_id=entry[5],
+                product_name=entry[6],
+                manufacturer_info_id=entry[7],
+                company_info_id=entry[8],
+                company_name=entry[9],
+            )
+            for sublist in inspections
+            for entry in sublist
+        ]
+
+        return inspections

--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -6,7 +6,7 @@ from fastapi.logger import logger
 from app.connection_manager import ConnectionManager
 from app.constants import FERTISCAN_STORAGE_URL
 from app.exceptions import (
-    MissingUsernameError,
+    MissingUserAttributeError,
     UserConflictError,
     UserNotFoundError,
     log_error,
@@ -23,14 +23,14 @@ async def sign_up(cm: ConnectionManager, user: User) -> User:
         user (User): User instance containing user details.
 
     Raises:
-        MissingUsernameError: If the username is not provided.
+        MissingUserAttributeError: If the username is not provided.
         UserConflictError: If a user with the same username already exists.
 
     Returns:
         User: User object with assigned ID from the database.
     """
     if not user.username:
-        raise MissingUsernameError("Username is required for sign-up.")
+        raise MissingUserAttributeError("Username is required for sign-up.")
 
     try:
         with cm, cm.get_cursor() as cursor:
@@ -52,14 +52,14 @@ async def sign_in(cm: ConnectionManager, user: User) -> User:
         user (User): User instance containing user details.
 
     Raises:
-        MissingUsernameError: If the username is not provided.
+        MissingUserAttributeError: If the username is not provided.
         UserNotFoundError: If the user is not found in the database.
 
     Returns:
         User: User object with the retrieved ID from the database.
     """
     if not user.username:
-        raise MissingUsernameError("Username is required for sign-in.")
+        raise MissingUserAttributeError("Username is required for sign-in.")
 
     try:
         with cm, cm.get_cursor() as cursor:

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -5,6 +5,8 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pipeline import GPT, OCR
 
 from app.connection_manager import ConnectionManager
+from app.controllers.users import sign_in
+from app.exceptions import UserNotFoundError
 from app.models.users import User
 
 auth = HTTPBasic()
@@ -41,3 +43,18 @@ def authenticate_user(credentials: HTTPBasicCredentials = Depends(auth)):
         )
 
     return User(username=credentials.username)
+
+
+async def fetch_user(
+    auth_user: User = Depends(authenticate_user),
+    cm: ConnectionManager = Depends(get_connection_manager),
+) -> User:
+    """
+    Fetches the authenticated user's info from db.
+    """
+    try:
+        return await sign_in(cm, auth_user)
+    except UserNotFoundError:
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED, detail="Invalid username or password"
+        )

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -15,7 +15,7 @@ class UserConflictError(UserError):
     pass
 
 
-class MissingUsernameError(UserError):
+class MissingUserAttributeError(UserError):
     pass
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,17 @@ from pipeline import GPT, OCR, FertilizerInspection
 from app.config import lifespan
 from app.connection_manager import ConnectionManager
 from app.controllers.data_extraction import extract_data
+from app.controllers.inspections import read_all
 from app.controllers.users import sign_in, sign_up
-from app.dependencies import authenticate_user, get_connection_manager, get_gpt, get_ocr
+from app.dependencies import (
+    authenticate_user,
+    fetch_user,
+    get_connection_manager,
+    get_gpt,
+    get_ocr,
+)
 from app.exceptions import UserConflictError, UserNotFoundError, log_error
+from app.models.inspection import InspectionData
 from app.models.monitoring import HealthStatus
 from app.models.users import User
 from app.sanitization import custom_secure_filename
@@ -79,3 +87,11 @@ async def login(
         return await sign_in(cm, user)
     except UserNotFoundError:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="User not found!")
+
+
+@app.get("/inspections", tags=["Inspections"], response_model=list[InspectionData])
+async def get_inspections(
+    cm: Annotated[ConnectionManager, Depends(get_connection_manager)],
+    user: User = Depends(fetch_user),
+):
+    return await read_all(cm, user)

--- a/app/main.py
+++ b/app/main.py
@@ -55,13 +55,7 @@ async def analyze_document(
     return extract_data(file_dict, ocr, gpt)
 
 
-@app.post(
-    "/signup",
-    tags=["Users"],
-    status_code=201,
-    response_model=User,
-    responses={HTTPStatus.CONFLICT: {"description": "User exists"}},
-)
+@app.post("/signup", tags=["Users"], status_code=201, response_model=User)
 async def signup(
     cm: Annotated[ConnectionManager, Depends(get_connection_manager)],
     user: User = Depends(authenticate_user),
@@ -72,13 +66,7 @@ async def signup(
         raise HTTPException(status_code=HTTPStatus.CONFLICT, detail="User exists!")
 
 
-@app.post(
-    "/login",
-    tags=["Users"],
-    status_code=200,
-    response_model=User,
-    responses={HTTPStatus.NOT_FOUND: {"description": "User not found"}},
-)
+@app.post("/login", tags=["Users"], status_code=200, response_model=User)
 async def login(
     cm: Annotated[ConnectionManager, Depends(get_connection_manager)],
     user: User = Depends(authenticate_user),
@@ -86,7 +74,9 @@ async def login(
     try:
         return await sign_in(cm, user)
     except UserNotFoundError:
-        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="User not found!")
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED, detail="Invalid username or password"
+        )
 
 
 @app.get("/inspections", tags=["Inspections"], response_model=list[InspectionData])

--- a/app/models/inspection.py
+++ b/app/models/inspection.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from pydantic import UUID4, BaseModel
+
+
+class InspectionData(BaseModel):
+    id: UUID4
+    upload_date: datetime
+    updated_at: datetime | None = None
+    sample_id: UUID4 | None = None
+    picture_set_id: UUID4 | None = None
+    label_info_id: UUID4
+    product_name: str | None = None
+    manufacturer_info_id: UUID4 | None = None
+    company_info_id: UUID4 | None = None
+    company_name: str | None = None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -128,7 +128,7 @@ class TestAPI(unittest.TestCase):
                     "Authorization": f"Basic {self.credentials(new_username, self.password)}",
                 },
             )
-            self.assertEqual(response.status_code, 404, response.json())
+            self.assertEqual(response.status_code, 401, response.json())
 
     @patch("app.main.extract_data")
     def test_analyze_document(self, mock_extract_data):
@@ -210,7 +210,6 @@ class TestAPI(unittest.TestCase):
 
         with TestClient(app) as client:
             response = client.post("/analyze", files=files)
-            print("response.status_code", response.status_code)
             self.assertEqual(response.status_code, 422)
 
     @patch("app.constants.UPLOAD_FOLDER", new_callable=tempfile.TemporaryDirectory)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -228,3 +228,64 @@ class TestAPI(unittest.TestCase):
 
             response_data = response.json()
             FertilizerInspection.model_validate(response_data)
+
+    def test_get_inspections_success(self):
+        with TestClient(app) as client:
+            client.post(
+                "/signup",
+                headers={
+                    **self.headers,
+                    "Authorization": f"Basic {self.credentials(self.username, self.password)}",
+                },
+            )
+
+            response = client.get(
+                "/inspections",
+                headers={
+                    **self.headers,
+                    "Authorization": f"Basic {self.credentials(self.username, self.password)}",
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertListEqual(response.json(), [])
+
+    def test_get_inspections_unauthorized(self):
+        with TestClient(app) as client:
+            # Attempt to access the /inspections endpoint without authentication headers
+            response = client.get("/inspections")
+
+            # Verify the response status code is 401 Unauthorized
+            self.assertEqual(response.status_code, 401)
+
+    def test_get_inspections_with_invalid_auth(self):
+        with TestClient(app) as client:
+            # Generate an invalid username using a random UUID hex
+            invalid_username = uuid.uuid4().hex
+            invalid_password = "wrongpassword"
+
+            # Attempt to access the /inspections endpoint with invalid credentials
+            response = client.get(
+                "/inspections",
+                headers={
+                    **self.headers,
+                    "Authorization": f"Basic {self.credentials(invalid_username, invalid_password)}",
+                },
+            )
+
+            # Verify the response status code is 401 Unauthorized
+            self.assertEqual(response.status_code, 401)
+
+    def test_get_inspections_missing_auth_credentials(self):
+        with TestClient(app) as client:
+            # Attempt to access the /inspections endpoint with an empty username
+            response = client.get(
+                "/inspections",
+                headers={
+                    **self.headers,
+                    "Authorization": f"Basic {self.credentials('', self.password)}",
+                },
+            )
+
+            # Verify the response status code is 400 Bad Request
+            self.assertEqual(response.status_code, 400)

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -169,7 +169,7 @@ class TestConnectionManagerIntegration(unittest.TestCase):
             )
             self.assertEqual(login_response.status_code, 200, login_response.json())
 
-        # Step 3: Verify that the user was rolled back (should return 404)
+        # Step 3: Verify that the user was rolled back (should return 401)
         with TestClient(app) as client:
             rollback_response = client.post(
                 "/login",
@@ -179,5 +179,5 @@ class TestConnectionManagerIntegration(unittest.TestCase):
                 },
             )
             self.assertEqual(
-                rollback_response.status_code, 404, rollback_response.json()
+                rollback_response.status_code, 401, rollback_response.json()
             )

--- a/tests/test_inspections.py
+++ b/tests/test_inspections.py
@@ -1,0 +1,92 @@
+import unittest
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.connection_manager import ConnectionManager
+from app.controllers.inspections import read_all
+from app.exceptions import MissingUserAttributeError
+from app.models.users import User
+
+
+class TestReadAll(unittest.IsolatedAsyncioTestCase):
+    async def test_missing_user_id_raises_error(self):
+        cm = AsyncMock(spec=ConnectionManager)
+        user = User(id=None)
+
+        with self.assertRaises(MissingUserAttributeError):
+            await read_all(cm, user)
+
+    @patch("app.controllers.inspections.get_user_analysis_by_verified")
+    async def test_calls_analysis_twice_and_combines_results(
+        self, mock_get_user_analysis_by_verified
+    ):
+        # Set up mock return values for verified and unverified data
+        mock_get_user_analysis_by_verified.side_effect = [
+            [
+                (
+                    uuid.uuid4(),
+                    datetime(2023, 1, 1),
+                    datetime(2023, 1, 2),
+                    uuid.uuid4(),
+                    uuid.uuid4(),
+                    uuid.uuid4(),
+                    "Product A",
+                    uuid.uuid4(),
+                    uuid.uuid4(),
+                    "Company A",
+                )
+            ],
+            [
+                (
+                    uuid.uuid4(),
+                    datetime(2023, 1, 3),
+                    datetime(2023, 1, 4),
+                    uuid.uuid4(),
+                    uuid.uuid4(),
+                    uuid.uuid4(),
+                    "Product B",
+                    uuid.uuid4(),
+                    uuid.uuid4(),
+                    "Company B",
+                )
+            ],
+        ]
+
+        cm = AsyncMock(spec=ConnectionManager)
+        cm.get_cursor.return_value.__enter__.return_value = MagicMock()
+        user = User(id=uuid.uuid4())
+
+        # Execute the function
+        inspections = await read_all(cm, user)
+
+        # Check that get_user_analysis_by_verified was called twice
+        self.assertEqual(mock_get_user_analysis_by_verified.call_count, 2)
+        mock_get_user_analysis_by_verified.assert_any_call(
+            cm.get_cursor.return_value.__enter__.return_value, user.id, True
+        )
+        mock_get_user_analysis_by_verified.assert_any_call(
+            cm.get_cursor.return_value.__enter__.return_value, user.id, False
+        )
+
+        # Verify that the result is a list of InspectionData objects with correct length and data
+        self.assertEqual(len(inspections), 2)
+        self.assertEqual(inspections[0].product_name, "Product A")
+        self.assertEqual(inspections[1].product_name, "Product B")
+
+    @patch("app.controllers.inspections.get_user_analysis_by_verified")
+    async def test_no_inspections_for_verified_and_unverified(
+        self, mock_get_user_analysis_by_verified
+    ):
+        # Mock empty results for both verified and unverified inspections
+        mock_get_user_analysis_by_verified.side_effect = [[], []]
+
+        cm = AsyncMock(spec=ConnectionManager)
+        cm.get_cursor.return_value.__enter__.return_value = MagicMock()
+        user = User(id=uuid.uuid4())
+
+        # Execute the function
+        inspections = await read_all(cm, user)
+
+        # Verify that an empty list is returned when there are no inspections
+        self.assertEqual(len(inspections), 0)

--- a/tests/test_users_controller.py
+++ b/tests/test_users_controller.py
@@ -6,7 +6,11 @@ from datastore.db.queries.user import UserNotFoundError as DBUserNotFoundError
 
 from app.connection_manager import ConnectionManager
 from app.controllers.users import sign_in, sign_up
-from app.exceptions import MissingUsernameError, UserConflictError, UserNotFoundError
+from app.exceptions import (
+    MissingUserAttributeError,
+    UserConflictError,
+    UserNotFoundError,
+)
 from app.models.users import User
 
 
@@ -41,7 +45,7 @@ class TestSignUpSuccess(unittest.IsolatedAsyncioTestCase):
         mock_user = User(username="")  # Empty username
 
         # Act & Assert
-        with self.assertRaises(MissingUsernameError):
+        with self.assertRaises(MissingUserAttributeError):
             await sign_up(mock_cm, mock_user)
 
     async def test_sign_up_user_already_exists(self):
@@ -85,7 +89,7 @@ class TestSignUpSuccess(unittest.IsolatedAsyncioTestCase):
         mock_user = User(username="")  # Empty username
 
         # Act & Assert
-        with self.assertRaises(MissingUsernameError):
+        with self.assertRaises(MissingUserAttributeError):
             await sign_in(mock_cm, mock_user)
 
     async def test_sign_in_user_not_found(self):


### PR DESCRIPTION
- [x] get inspections route
- [x] login now raises 401 instead of 404
- [x] tests

> [!NOTE]  
> Before, the route returned a list of db records (a list of lists of strings). Now it returns an object.