### PR TITLE
Issue #200: add OpenTelemetry instrumentation for enhanced monitoring and logging

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,7 +10,7 @@ UPLOAD_PATH='./uploads'
 # LOG_FILENAME='fertiscan.log'
 
 # For CORS purposes
-ALLOWED_ORIGINS=FRONTEND_URL=[""]
+ALLOWED_ORIGINS=[""]
 
 # API base path for deployment
 API_BASE_PATH='/swagger'

--- a/.env.template
+++ b/.env.template
@@ -10,7 +10,7 @@ UPLOAD_PATH='./uploads'
 # LOG_FILENAME='fertiscan.log'
 
 # For CORS purposes
-FRONTEND_URL=""
+ALLOWED_ORIGINS=FRONTEND_URL=[""]
 
 # API base path for deployment
 API_BASE_PATH='/swagger'
@@ -22,4 +22,5 @@ FERTISCAN_SCHEMA=
 FERTISCAN_DB_URL=
 
 # Phoenix API configuration
+PHOENIX_ENDPOINT=
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Follow the guidelines in
     --build-arg ARG_AZURE_OPENAI_API_KEY=your_azure_openai_key \
     --build-arg ARG_PROMPT_PATH=path/to/prompt_file \
     --build-arg ARG_UPLOAD_PATH=path/to/upload_file \
-    --build-arg ARG_FRONTEND_URL=http://url.to_frontend/ \
+    --build-arg ALLOWED_ORIGINS=["http://url.to_frontend/"] \
     .
     ```
 
@@ -110,7 +110,7 @@ AZURE_OPENAI_DEPLOYMENT=your_azure_openai_deployment
 
 PROMPT_PATH=path/to/file
 UPLOAD_PATH=path/to/file
-FRONTEND_URL=http://url.to_frontend/
+ALLOWED_ORIGINS=["http://url.to_frontend/"]
 ```
 
 ## Style Guides

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY . .
 
 RUN pip install --no-cache-dir -r requirements.txt
+RUN opentelemetry-bootstrap --action=install
 
 ARG ARG_AZURE_API_ENDPOINT
 ARG ARG_AZURE_API_KEY
@@ -14,7 +15,7 @@ ARG ARG_AZURE_OPENAI_KEY
 ARG ARG_FERTISCAN_STORAGE_URL
 ARG ARG_FERTISCAN_DB_URL
 ARG ARG_FERTISCAN_SCHEMA
-ARG ARG_FRONTEND_URL
+ARG ARG_ALLOWED_ORIGINS
 ARG ARG_PROMPT_PATH
 ARG ARG_UPLOAD_PATH
 
@@ -26,7 +27,7 @@ ENV AZURE_OPENAI_KEY=${ARG_AZURE_OPENAI_KEY:-your_azure_openai_key}
 ENV FERTISCAN_STORAGE_URL=${ARG_FERTISCAN_STORAGE_URL:-your_fertiscan_storage_url}
 ENV FERTISCAN_DB_URL=${ARG_FERTISCAN_DB_URL:-your_fertiscan_db_url}
 ENV FERTISCAN_SCHEMA=${ARG_FERTISCAN_SCHEMA:-your_fertiscan_schema}
-ENV FRONTEND_URL=${ARG_FRONTEND_URL:-http://url.to_frontend/}
+ENV ALLOWED_ORIGINS=${ARG_ALLOWED_ORIGINS:-["http://url.to_frontend/"]}
 ENV PROMPT_PATH=${ARG_PROMPT_PATH:-path/to/file}
 ENV UPLOAD_PATH=${ARG_UPLOAD_PATH:-path/to/file}
 
@@ -36,8 +37,6 @@ RUN chown -R 1000:1000 /app
 RUN mkdir -p /cachedir_joblib && chown -R 1000:1000 /cachedir_joblib
 RUN mkdir -p /.dspy_cache && chown -R 1000:1000 /.dspy_cache
 
-RUN opentelemetry-bootstrap --action=install
-
 USER 1000
 
-CMD ["opentelemetry-instrument", "fastapi", "run", "app/main.py", "--port", "5000"]
+CMD ["opentelemetry-instrument", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ generation using an [LLM](https://en.wikipedia.org/wiki/Large_language_model).
     --build-arg ARG_FERTISCAN_STORAGE_URL=your_fertiscan_storage_url \
     --build-arg ARG_FERTISCAN_DB_URL=your_fertiscan_db_url \
     --build-arg ARG_FERTISCAN_SCHEMA=your_fertiscan_schema \
-    --build-arg ARG_FRONTEND_URL=http://url.to_frontend/ \
+    --build-arg ARG_ALLOWED_ORIGINS=["http://url.to_frontend/"] \
     --build-arg OTEL_EXPORTER_OTLP_ENDPOINT=your_phoenix_endpoint \
     --build-arg ARG_PROMPT_PATH=path/to/file \
     --build-arg ARG_UPLOAD_PATH=path/to/file \
@@ -124,7 +124,7 @@ FERTISCAN_DB_URL=your_fertiscan_db_url
 FERTISCAN_SCHEMA=your_fertiscan_schema
 
 UPLOAD_PATH=path/to/file
-FRONTEND_URL=http://url.to_frontend/
+ALLOWED_ORIGINS=["http://url.to_frontend/"]
 ```
 
 ## API Endpoints

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,15 +36,27 @@ services:
     restart: always
     env_file:
       - .env
+    environment:
+    - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
+    - OTEL_EXPORTER_OTLP_INSECURE=true
+    - OTEL_TRACES_EXPORTER=otlp
+    - OTEL_METRICS_EXPORTER=otlp
+    - OTEL_LOGS_EXPORTER=otlp
+    - OTEL_PYTHON_LOG_CORRELATION=true
+    - OTEL_TRACES_SAMPLER=always_on
+    - OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+    - OTEL_PYTHON_LOGGING_LOG_LEVEL=DEBUG
+    - OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST=".*"
+    - OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE=".*"
+    - OTEL_PYTHON_FASTAPI_EXCLUDED_URLS="health"
+    - OTEL_SERVICE_NAME="fertiscan-backend"
+    - OTEL_RESOURCE_ATTRIBUTES="service.name=fertiscan-backend"
+    - OTEL_LOG_LEVEL=DEBUG
+    - ALLOWED_ORIGINS=["http://localhost:3000"]
     depends_on:
       - postgres
     ports:
       - "5001:5000" # if you want to run the backend on a different port, change the first port number
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
     networks:
       - fertiscan-network
 
@@ -92,6 +104,68 @@ services:
     depends_on:
       - postgres
 
+  prometheus:
+    image: ghcr.io/ai-cfia/prometheus:0.0.2
+    container_name: prometheus
+    environment:
+      - ENABLE_BACKEND_METRICS=false
+    ports:
+      - "9090:9090"
+    networks:
+      - fertiscan-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_FEATURE_TOGGLES_ENABLE=flameGraph traceqlSearch traceQLStreaming correlations metricsSummary traceqlEditor traceToMetrics datatrails
+      - GF_INSTALL_PLUGINS=grafana-lokiexplore-app,grafana-exploretraces-app
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    networks:
+      - fertiscan-network
+    depends_on:
+      - prometheus
+      - loki
+      - tempo
+
+  loki:
+    image: ghcr.io/ai-cfia/loki:0.0.1
+    container_name: loki
+    ports:
+      - "3100:3100"
+    user: root
+    volumes:
+      - "loki-data:/data/loki"
+    networks:
+      - fertiscan-network
+
+
+  tempo:
+    image: ghcr.io/ai-cfia/tempo:0.0.1
+    container_name: tempo
+    ports:
+      - "3200:3200"
+      - "4327:4317"
+      - "4328:4318"
+    networks:
+      - fertiscan-network
+
+  alloy:
+    image: ghcr.io/ai-cfia/alloy:0.0.1
+    container_name: alloy
+    ports:
+      - "12347:12345"
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - fertiscan-network
+
 networks:
   fertiscan-network:
     driver: bridge
@@ -99,3 +173,5 @@ networks:
 volumes:
   postgres-data:
   pgadmin:
+  grafana_data:
+  loki-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - fertiscan-network
 
   frontend:
-    image: ghcr.io/ai-cfia/fertiscan-frontend:main
+    image: ghcr.io/ai-cfia/fertiscan-frontend:304-adapt-alpha-v100-to-fastapi-backend-and-minor-fixes
     container_name: frontend
     restart: always
     ports:
@@ -53,6 +53,7 @@ services:
     - OTEL_RESOURCE_ATTRIBUTES="service.name=fertiscan-backend"
     - OTEL_LOG_LEVEL=DEBUG
     - ALLOWED_ORIGINS=["http://localhost:3000"]
+    - PHOENIX_ENDPOINT=http://phoenix:6006/v1/traces
     depends_on:
       - postgres
     ports:
@@ -166,6 +167,36 @@ services:
     networks:
       - fertiscan-network
 
+  phoenix:
+    container_name: phoenix
+    image: arizephoenix/phoenix:latest
+    restart: always
+    depends_on:
+      - phoenix-postgres
+    ports:
+      - 6006:6006
+      - 4343:4317
+    environment:
+      - PHOENIX_SQL_DATABASE_URL=postgresql://postgres:postgres@phoenix-postgres:5432/postgres
+    networks:
+      - fertiscan-network
+
+  phoenix-postgres:
+    container_name: phoenix-postgres
+    image: postgres:16
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - 5433:5432
+    networks:
+      - fertiscan-network
+    volumes:
+      - phoenix-postgres-data:/var/lib/postgresql/data
+
+
 networks:
   fertiscan-network:
     driver: bridge
@@ -175,3 +206,4 @@ volumes:
   pgadmin:
   grafana_data:
   loki-data:
+  phoenix-postgres-data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,20 +8,20 @@
 
 The `/analyze` route serves to:
 
-- **Upload and Process Documents**: Allows clients to upload
- images of documents for analysis.
+- **Upload and Process Documents**: Allows clients to upload images of documents
+ for analysis.
 - **Extract and Structure Data**: Utilizes Azure Document Intelligence to
  extract text and layout information from the uploaded documents.
 - **Generate Forms**: Uses OpenAI's GPT-4 to generate a structured JSON
- inspection containing all the necessary information extracted from the document.
+ inspection containing all the necessary information extracted from the
+ document.
 - **Provide Responses**: Returns the generated inspection to the client,
- facilitating the inspection and validation processes
- by providing all relevant data in a structured format.
+ facilitating the inspection and validation processes by providing all relevant
+ data in a structured format.
 
-In essence, the `/analyze` route automates the
- extraction and structuring of data from documents, significantly
- simplifying the workflow for
- users who need to process and analyze document content.
+In essence, the `/analyze` route automates the extraction and structuring of
+ data from documents, significantly simplifying the workflow for users who need
+ to process and analyze document content.
 
 ## Deployment
 
@@ -39,8 +39,8 @@ In essence, the `/analyze` route automates the
 
 ### Database
 
-- **Description**: The database where the
- information on fertiliser and labels is stored.
+- **Description**: The database where the information on fertiliser and labels
+ is stored.
 - **Repository**: <https://github.com/ai-cfia/ailab-datastore/>
 
 ## API Endpoints
@@ -80,3 +80,8 @@ Retrieve a list of inspections matching the search query.
 ![search](../out/get_inspections_dss/FertiScan%20Sequence%20Diagram.png)
 
 v1.0.0
+
+## Instrumentation
+
+For monitoring and logging, refer to the [following
+documentation.](./otel/README.md)

--- a/docs/otel/README.md
+++ b/docs/otel/README.md
@@ -100,7 +100,8 @@ the repository
 To start the application and associated services, use the following command:
 
 ```bash
-docker-compose up -d
+# Make sure you run `--build` once. then yoy can omit it.
+docker-compose up --build -d
 ```
 
 ### Accessing Monitoring Tools

--- a/docs/otel/README.md
+++ b/docs/otel/README.md
@@ -5,9 +5,11 @@ The application is instrumented with
 traces and logs. This setup uses **programmatic instrumentation**, providing
 control over how OpenTelemetry is initialized and avoiding potential issues with
 zero-code instrumentation. This allows us to send traces and logs from FastAPI
-endpoints to an OpenTelemetry collector, where
-[Alloy](https://grafana.com/docs/alloy/latest/) acts as the centralized
-receiver, forwarding logs to Loki and traces to Tempo.
+endpoints to an OpenTelemetry collector. The traces and logs can be routed to
+[Alloy](https://grafana.com/docs/alloy/latest/) (centralized receiver for logs
+and traces sent to Loki and Tempo) or
+[Phoenix](https://github.com/Arize-ai/phoenix) ( AI observability platform)
+based on the configuration.
 
 ---
 
@@ -82,25 +84,37 @@ In this code:
 4. **Logging Handler**: The `LoggingHandler` attaches to FastAPI’s `logger`
    module, ensuring all logs are processed by OpenTelemetry's provider.
 
+### Phoenix Trace Routing
+
+To enable **Phoenix** as the trace receiver, set the `PHOENIX_ENDPOINT`
+environment variable to `http://phoenix:6006/v1/traces`. When this variable is
+set, traces are routed to Phoenix; otherwise, the traces will default to
+**Alloy-Tempo** instance.
+
+- **Phoenix enabled (default in `docker-compose.yml`)**: Traces are sent to
+  Phoenix.
+- **Phoenix disabled (remove or comment `PHOENIX_ENDPOINT`)**: Traces route to
+  Alloy’s Tempo instance.
+
 ### Docker Compose Configuration
 
 The `docker-compose.yml` emulates our production environment, with the
 OpenTelemetry collector and related components configured to handle and display
-telemetry data.
+telemetry data. Phoenix’s configuration is included to provide additional AI
+observability, dataset versioning, and evaluation functionalities.
 
-You will notice that some services are configured with custom image from our
+You will notice that some services are configured with custom images from our
 Docker registry. This is because we have built custom images for these services
-with their respective configuration as mean to prevent any misconfiguration and
-cluttering the current repository. Their respective Dockerfiles can be found in
-the repository
-[Devops](https://github.com/ai-cfia/devops/tree/main/dockerfiles).
+to streamline configuration and prevent misconfiguration. Their respective
+Dockerfiles can be found in the
+[Devops](https://github.com/ai-cfia/devops/tree/main/dockerfiles) repository.
 
 ## Running the Application
 
 To start the application and associated services, use the following command:
 
 ```bash
-# Make sure you run `--build` once. then yoy can omit it.
+# Make sure you run `--build` once, then you can omit it.
 docker-compose up --build -d
 ```
 
@@ -111,6 +125,8 @@ debugging:
 
 - **Grafana (for visualization)**: Visit `http://localhost:3001` and configure
   Grafana to use Tempo and Loki as data sources.
+- **Phoenix (for AI observability)**: Visit `http://localhost:6006` to view
+  trace data, datasets, and experiment tracking.
 - **Prometheus (for metrics)**: Accessible at `http://localhost:9090`.
 - **pgAdmin (for database management)**: Accessible at `http://localhost:5050`.
 
@@ -125,4 +141,4 @@ debugging:
 
 This setup ensures that logs, traces, and metrics are correctly collected and
 visualized, providing a comprehensive view of application performance and
-behavior across services.
+behavior across services, with optional AI observability through Phoenix.

--- a/docs/otel/README.md
+++ b/docs/otel/README.md
@@ -15,8 +15,8 @@ receiver, forwarding logs to Loki and traces to Tempo.
 
 ### FastAPI Application Code
 
-The code below demonstrates how we set up in `app/config.py` tracing and logging in the
-`fertiscan-backend` service using OpenTelemetry. This configuration uses
+The code below demonstrates how we set up in `app/config.py` tracing and logging
+in the `fertiscan-backend` service using OpenTelemetry. This configuration uses
 FastAPI's `lifespan` parameter, a context manager that allows controlled setup
 and shutdown of resources (in this case, OpenTelemetry's logging and tracing
 providers).

--- a/docs/otel/README.md
+++ b/docs/otel/README.md
@@ -1,0 +1,127 @@
+# OpenTelemetry Instrumentation
+
+The application is instrumented with
+[OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) to collect
+traces and logs. This setup uses **programmatic instrumentation**, providing
+control over how OpenTelemetry is initialized and avoiding potential issues with
+zero-code instrumentation. This allows us to send traces and logs from FastAPI
+endpoints to an OpenTelemetry collector, where
+[Alloy](https://grafana.com/docs/alloy/latest/) acts as the centralized
+receiver, forwarding logs to Loki and traces to Tempo.
+
+---
+
+## Configuration and Instrumentation
+
+### FastAPI Application Code
+
+The code below demonstrates how we set up in `app/config.py` tracing and logging in the
+`fertiscan-backend` service using OpenTelemetry. This configuration uses
+FastAPI's `lifespan` parameter, a context manager that allows controlled setup
+and shutdown of resources (in this case, OpenTelemetry's logging and tracing
+providers).
+
+```python
+from contextlib import asynccontextmanager
+
+[...]
+
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+   [...]
+
+    resource = Resource.create(
+        {
+            "service.name": "fertiscan-backend",
+        }
+    )
+
+    # Tracing setup
+    tracer_provider = TracerProvider(resource=resource)
+    trace.set_tracer_provider(tracer_provider)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=c.OTEL_EXPORTER_OTLP_ENDPOINT, insecure=True))
+    )
+    # Logging setup
+    logger_provider = LoggerProvider(resource=resource)
+    set_logger_provider(logger_provider)
+    logger_provider.add_log_record_processor(
+        BatchLogRecordProcessor(OTLPLogExporter(endpoint=c.OTEL_EXPORTER_OTLP_ENDPOINT, insecure=True))
+    )
+    handler = LoggingHandler(logging.NOTSET, logger_provider=logger_provider)
+    logger.addHandler(handler)
+
+    # Yield control back to FastAPI, indicating setup completion
+    yield
+
+    [...]
+
+    # Shutdown the logging and tracing providers
+    logger_provider.shutdown()
+    tracer_provider.shutdown()
+```
+
+In this code:
+
+1. **Resource Attributes**: `service.name` is set as "fertiscan-backend" to tag
+   logs and traces from this service.
+2. **Tracing Configuration**: `TracerProvider` is set with an `OTLPSpanExporter`
+   to send traces to Alloy at `http://alloy:4317`.
+3. **Logging Configuration**: `LoggerProvider` with `OTLPLogExporter` exports
+   logs to Alloy at the same endpoint.
+4. **Logging Handler**: The `LoggingHandler` attaches to FastAPI’s `logger`
+   module, ensuring all logs are processed by OpenTelemetry's provider.
+
+### Docker Compose Configuration
+
+The `docker-compose.yml` emulates our production environment, with the
+OpenTelemetry collector and related components configured to handle and display
+telemetry data.
+
+You will notice that some services are configured with custom image from our
+Docker registry. This is because we have built custom images for these services
+with their respective configuration as mean to prevent any misconfiguration and
+cluttering the current repository. Their respective Dockerfiles can be found in
+the repository
+[Devops](https://github.com/ai-cfia/devops/tree/main/dockerfiles).
+
+## Running the Application
+
+To start the application and associated services, use the following command:
+
+```bash
+docker-compose up -d
+```
+
+### Accessing Monitoring Tools
+
+After deploying the stack, you can access the following tools for monitoring and
+debugging:
+
+- **Grafana (for visualization)**: Visit `http://localhost:3001` and configure
+  Grafana to use Tempo and Loki as data sources.
+- **Prometheus (for metrics)**: Accessible at `http://localhost:9090`.
+- **pgAdmin (for database management)**: Accessible at `http://localhost:5050`.
+
+### Connecting Data Sources in Grafana
+
+1. **Loki**: Add Loki as a data source in Grafana for log visualization. Point
+   to `http://loki:3100` as the data source URL.
+2. **Tempo**: Add Tempo as a data source for trace visualization, using
+   `http://tempo:3200` as the URL.
+3. **Prometheus (Optional)**: Connect Prometheus to Grafana for metrics by
+   pointing to `http://prometheus:9090`.
+
+This setup ensures that logs, traces, and metrics are correctly collected and
+visualized, providing a comprehensive view of application performance and
+behavior across services.


### PR DESCRIPTION
This PR introduces OpenTelemetry instrumentation into the `fertiscan-backend` service to capture detailed telemetry data and forward it to our centralized OTLP receiver, Alloy. This setup enables comprehensive logging and tracing, aligned with our production monitoring stack, where Alloy directs logs to Loki and traces to Tempo.

### Changes Introduced

- **OTLP Configuration**: Configures Alloy as the OTLP receiver via gRPC on `http://alloy:4317`, supporting both logs and traces.
- **Logging and Tracing Integration**: Initializes `TracerProvider` and `LoggerProvider` with `OTLPSpanExporter` and `OTLPLogExporter`, respectively. Initial tests confirmed that non-route-based logs were being exported as expected.
- **Dockerized Monitoring Stack**: The `docker-compose.yml` emulates the production environment, incorporating the OpenTelemetry collector and tools like Grafana and Prometheus for visualization and debugging. Custom Docker images have been added from our DevOps repository to maintain configuration consistency and streamline the setup.
  - **Grafana**: For visualization, accessible at `http://localhost:3001`.
  - **Prometheus**: For metrics at `http://localhost:9090`.
  - **Tempo**: For traces.
  - **Loki**: For logs.

### Setbacks and Observations

1. **Missing route logs**: Initially, only non-route logs were exported successfully. Logs generated within FastAPI endpoints did not appear in Alloy, pointing to context propagation issues in the FastAPI routes.
2. **Trace consistency issues**: Traces were intermittently missing `trace_id` and `span_id` values due to a reload behavior in the Docker configuration (`CMD ["opentelemetry-instrument", "fastapi", "run", "app/main.py", "--port", "5000"]`). Switching to `uvicorn` (`CMD ["opentelemetry-instrument", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]`) mitigated some issues but did not fully resolve the logging concerns.
3. **Application reload impact**: FastAPI’s reload behavior appeared to disrupt `LoggerProvider`, leading to missing route-specific logs even though standalone tests succeeded. A lifespan context manager was ultimately employed to stabilize the setup.

### Final Solution

The integration of a `lifespan` context manager allowed consistent initialization and shutdown of `LoggerProvider` and `TracerProvider`. This approach ensured that route-based logs and traces were reliably exported, with consistent `trace_id` and `span_id` values across endpoints.

Side note : 
I didn't set up log level so its using INFO level by default.  This means that any logs with a level of INFO or higher (like WARNING, ERROR, and CRITICAL) will be displayed by default.

Since were not really doing logging as of now, a quick way to test that the logging instrumentation works is to add in `main.py` :
```python
@app.get("/health", tags=["Monitoring"], response_model=HealthStatus)
async def health_check():
    # add this line
    log_error("Health check")
    return HealthStatus()
 ```
And test the endpoint to see instrumentation in grafana using Loki as datasource.