### PR TITLE
issue #237: fix indexerror in read all inspections

### DIFF
--- a/.env.config
+++ b/.env.config
@@ -13,7 +13,7 @@ API_BASE_PATH=
 SWAGGER_PATH=/docs
 
 # DB
-FERTISCAN_SCHEMA=fertiscan_0.0.18
+FERTISCAN_SCHEMA=fertiscan_0.0.19
 
 # Phoenix API configuration
 PHOENIX_ENDPOINT=

--- a/app/controllers/inspections.py
+++ b/app/controllers/inspections.py
@@ -2,6 +2,7 @@ import asyncio
 from uuid import UUID
 
 from azure.storage.blob import ContainerClient
+from datastore.blob.azure_storage_api import build_container_name
 from fertiscan import delete_inspection as db_delete_inspection
 from fertiscan import (
     get_full_inspection_json,
@@ -44,9 +45,9 @@ async def read_all_inspections(cp: ConnectionPool, user: User):
                 picture_set_id=entry[4],
                 label_info_id=entry[5],
                 product_name=entry[6],
-                manufacturer_info_id=entry[7],
-                company_info_id=entry[8],
-                company_name=entry[9],
+                main_organization_id=entry[7],
+                main_organization_name=entry[8],
+                # verified=entry[9],
             )
             for sublist in inspections
             for entry in sublist
@@ -88,7 +89,7 @@ async def create_inspection(
 
     with cp.connection() as conn, conn.cursor() as cursor:
         container_client = ContainerClient.from_connection_string(
-            connection_string, container_name=f"user-{user.id}"
+            connection_string, container_name=build_container_name(str(user.id))
         )
         label_data = label_data.model_dump(mode="json")
         inspection = await register_analysis(
@@ -139,7 +140,7 @@ async def delete_inspection(
         id = UUID(id)
 
     container_client = ContainerClient.from_connection_string(
-        connection_string, container_name=f"user-{user.id}"
+        connection_string, container_name=build_container_name(str(user.id))
     )
 
     with cp.connection() as conn, conn.cursor() as cursor:

--- a/app/controllers/inspections.py
+++ b/app/controllers/inspections.py
@@ -47,7 +47,7 @@ async def read_all_inspections(cp: ConnectionPool, user: User):
                 product_name=entry[6],
                 main_organization_id=entry[7],
                 main_organization_name=entry[8],
-                # verified=entry[9],
+                verified=entry[9],
             )
             for sublist in inspections
             for entry in sublist

--- a/app/models/inspections.py
+++ b/app/models/inspections.py
@@ -5,17 +5,11 @@ from fertiscan.db.metadata.inspection import DBInspection, Inspection
 from fertiscan.db.metadata.inspection import (
     OrganizationInformation as DBOrganizationInformation,
 )
-from fertiscan.db.metadata.inspection import ProductInformation as DBProductInformation
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class OrganizationInformation(DBOrganizationInformation):
     id: UUID | None = None
-
-
-class ProductInformation(DBProductInformation):
-    label_id: UUID | None = None
-    registration_number: str | None = Field(None, pattern=r"^\d{7}[A-Z]$")
 
 
 class InspectionData(BaseModel):
@@ -26,9 +20,9 @@ class InspectionData(BaseModel):
     picture_set_id: UUID | None = None
     label_info_id: UUID
     product_name: str | None = None
-    manufacturer_info_id: UUID | None = None
-    company_info_id: UUID | None = None
-    company_name: str | None = None
+    main_organization_id: UUID | None = None
+    main_organization_name: str | None = None
+    # verified: bool | None = None
 
 
 class InspectionUpdate(Inspection):

--- a/app/models/inspections.py
+++ b/app/models/inspections.py
@@ -22,7 +22,7 @@ class InspectionData(BaseModel):
     product_name: str | None = None
     main_organization_id: UUID | None = None
     main_organization_name: str | None = None
-    # verified: bool | None = None
+    verified: bool | None = None
 
 
 class InspectionUpdate(Inspection):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv==1.0.1
 git+https://github.com/ai-cfia/fertiscan-pipeline.git@v0.0.11
-git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.14-fertiscan-datastore
+git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.15-fertiscan-datastore
 psycopg[pool]
 opentelemetry-api==1.27.0
 opentelemetry-sdk==1.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv==1.0.1
 git+https://github.com/ai-cfia/fertiscan-pipeline.git@v0.0.11
-git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.15-fertiscan-datastore
+git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.16-fertiscan-datastore
 psycopg[pool]
 opentelemetry-api==1.27.0
 opentelemetry-sdk==1.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv==1.0.1
 git+https://github.com/ai-cfia/fertiscan-pipeline.git@v0.0.11
-git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.13-fertiscan-datastore
+git+https://github.com/ai-cfia/ailab-datastore.git@v1.0.14-fertiscan-datastore
 psycopg[pool]
 opentelemetry-api==1.27.0
 opentelemetry-sdk==1.27.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -249,7 +249,7 @@ class TestAPIInspections(unittest.TestCase):
                 product_name="Product A",
                 main_organization_id=uuid.uuid4(),
                 main_organization_name="Company A",
-                # verified=True,
+                verified=True,
             ),
             InspectionData(
                 id=uuid.uuid4(),
@@ -261,7 +261,7 @@ class TestAPIInspections(unittest.TestCase):
                 product_name="Product B",
                 main_organization_id=uuid.uuid4(),
                 main_organization_name="Company B",
-                # verified=False,
+                verified=False,
             ),
         ]
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -302,6 +302,7 @@ class TestAPIInspections(unittest.TestCase):
                 "fr": [],
             },
             "ingredients": {"en": [], "fr": []},
+            "picture_set_id": str(uuid.uuid4()),
         }
         self.mock_inspection = InspectionResponse.model_validate(
             self.sample_inspection_dict

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -247,9 +247,9 @@ class TestAPIInspections(unittest.TestCase):
                 picture_set_id=uuid.uuid4(),
                 label_info_id=uuid.uuid4(),
                 product_name="Product A",
-                manufacturer_info_id=uuid.uuid4(),
-                company_info_id=uuid.uuid4(),
-                company_name="Company A",
+                main_organization_id=uuid.uuid4(),
+                main_organization_name="Company A",
+                # verified=True,
             ),
             InspectionData(
                 id=uuid.uuid4(),
@@ -259,9 +259,9 @@ class TestAPIInspections(unittest.TestCase):
                 picture_set_id=uuid.uuid4(),
                 label_info_id=uuid.uuid4(),
                 product_name="Product B",
-                manufacturer_info_id=uuid.uuid4(),
-                company_info_id=uuid.uuid4(),
-                company_name="Company B",
+                main_organization_id=uuid.uuid4(),
+                main_organization_name="Company B",
+                # verified=False,
             ),
         ]
 

--- a/tests/test_inspections.py
+++ b/tests/test_inspections.py
@@ -50,7 +50,7 @@ class TestReadAll(unittest.IsolatedAsyncioTestCase):
                     "Product A",
                     uuid.uuid4(),
                     "Company A",
-                    # True,
+                    True,
                 )
             ],
             [
@@ -64,7 +64,7 @@ class TestReadAll(unittest.IsolatedAsyncioTestCase):
                     "Product B",
                     uuid.uuid4(),
                     "Company B",
-                    # False,
+                    False,
                 )
             ],
         ]

--- a/tests/test_inspections.py
+++ b/tests/test_inspections.py
@@ -176,6 +176,7 @@ class TestRead(unittest.IsolatedAsyncioTestCase):
                 "fr": [],
             },
             "ingredients": {"en": [], "fr": []},
+            "picture_set_id": str(uuid.uuid4()),
         }
 
         mock_get_full_inspection_json.return_value = json.dumps(sample_inspection)
@@ -269,6 +270,7 @@ class TestCreateFunction(unittest.IsolatedAsyncioTestCase):
                 "fr": [],
             },
             "ingredients": {"en": [], "fr": []},
+            "picture_set_id": str(uuid.uuid4()),
         }
         mock_register_analysis.return_value = mock_inspection_data
 
@@ -353,6 +355,7 @@ class TestUpdateFunction(unittest.IsolatedAsyncioTestCase):
                 "fr": [],
             },
             "ingredients": {"en": [], "fr": []},
+            "picture_set_id": str(uuid.uuid4()),
         }
 
         # Convert dict to InspectionUpdate model for tests that require validation

--- a/tests/test_inspections.py
+++ b/tests/test_inspections.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+from datastore.blob.azure_storage_api import build_container_name
 from fertiscan.db.queries.inspection import (
     InspectionNotFoundError as DBInspectionNotFoundError,
 )
@@ -48,8 +49,8 @@ class TestReadAll(unittest.IsolatedAsyncioTestCase):
                     uuid.uuid4(),
                     "Product A",
                     uuid.uuid4(),
-                    uuid.uuid4(),
                     "Company A",
+                    # True,
                 )
             ],
             [
@@ -62,8 +63,8 @@ class TestReadAll(unittest.IsolatedAsyncioTestCase):
                     uuid.uuid4(),
                     "Product B",
                     uuid.uuid4(),
-                    uuid.uuid4(),
                     "Company B",
+                    # False,
                 )
             ],
         ]
@@ -280,7 +281,7 @@ class TestCreateFunction(unittest.IsolatedAsyncioTestCase):
         )
 
         mock_container_client.from_connection_string.assert_called_once_with(
-            fake_conn_str, container_name=f"user-{user.id}"
+            fake_conn_str, container_name=build_container_name(str(user.id))
         )
         mock_register_analysis.assert_called_once_with(
             cursor_mock,
@@ -492,7 +493,7 @@ class TestDeleteFunction(unittest.IsolatedAsyncioTestCase):
         )
 
         mock_container_client.from_connection_string.assert_called_once_with(
-            connection_string, container_name=f"user-{user.id}"
+            connection_string, container_name=build_container_name(str(user.id))
         )
         mock_db_delete_inspection.assert_called_once_with(
             cursor_mock, inspection_id, user.id, container_client_instance


### PR DESCRIPTION
- [x] use datastore function `generate_contaienr_name`
- [x] fix indexerror by updating the InspectionData model 
- [x] update datastore version to 1.0.15